### PR TITLE
build: error out if edl is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ macro(EDLCompileSym outName inName symName)
 		DEPENDS ${EDL_COMMAND})
 endmacro(EDLCompileSym)
 
+if(NOT DEFINED EDL_COMMAND)
+	message(FATAL_ERROR "You must define EDL_COMMAND with the path to the EDL executable!")
+endif(NOT DEFINED EDL_COMMAND)
+
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_C_STANDARD 99)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
I found the build setup a little confusing since it doesn't explicitly check to see if `EDL_COMMAND` is defined; I thought it'd be helpful to provide the user a message at the `cmake` step instead of waiting for the build to blow up.

```
CMake Error at CMakeLists.txt:24 (message):
  You must define EDL_COMMAND with the path to the EDL executable!
```